### PR TITLE
Fix incorrect diff when changing word order

### DIFF
--- a/Sources/TextDiffing/Internal/DiffSegment.swift
+++ b/Sources/TextDiffing/Internal/DiffSegment.swift
@@ -21,7 +21,7 @@ extension Array where Element == String {
         for change in diff {
             switch change {
             case let .insert(offset, element, _):
-                let deltaOffset = deletedOffsets.filter { $0 < offset }.count
+                let deltaOffset = deletedOffsets.filter { $0 <= offset }.count
                 segments.insert(DiffSegment(type: .inserted, element: element), at: offset + deltaOffset)
             case let .remove(offset, element, _):
                 deletedOffsets.insert(offset)

--- a/Tests/TextDiffingTests/TextDiffTests.swift
+++ b/Tests/TextDiffingTests/TextDiffTests.swift
@@ -1,0 +1,78 @@
+//
+//  TextDiffTests.swift
+//  TextDiffing
+//
+//  Created by Łukasz Rutkowski on 25/09/2025.
+//
+
+import Testing
+@testable import TextDiffing
+import Foundation
+
+@Suite struct TextDiffTests {
+
+    @Test func diffSegmentsWhenChangingWordOrder() async throws {
+        let diffSegments = diff("one two", and: "two one")
+        #expect(diffSegments == [
+            DiffSegment(type: .removed, element: "one "),
+            DiffSegment(type: .same, element: "two"),
+            DiffSegment(type: .inserted, element: " one")
+        ])
+    }
+
+    @Test func diffSegmentsWhenDeletingEverything() async throws {
+        let diffSegments = diff("sentence with some text", and: "")
+        #expect(diffSegments == [
+            DiffSegment(type: .removed, element: "sentence with some text")
+        ])
+    }
+
+    @Test func diffSegmentsWhenInsertingEverything() async throws {
+        let diffSegments = diff("", and: "sentence with some text")
+        #expect(diffSegments == [
+            DiffSegment(type: .inserted, element: "sentence with some text")
+        ])
+    }
+
+    @Test func diffSegmentsWhenDeletingWords() async throws {
+        let diffSegments = diff("a b c d", and: "a c")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "a "),
+            DiffSegment(type: .removed, element: "b "),
+            DiffSegment(type: .same, element: "c"),
+            DiffSegment(type: .removed, element: " d")
+        ])
+    }
+
+    @Test func diffSegmentsWhenInsertingWords() async throws {
+        let diffSegments = diff("a c", and: "a b c d")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "a "),
+            DiffSegment(type: .inserted, element: "b "),
+            DiffSegment(type: .same, element: "c"),
+            DiffSegment(type: .inserted, element: " d")
+        ])
+    }
+
+    @Test func diffSegmentsWhenChangingWord() async throws {
+        let diffSegments = diff("dog pig", and: "dog cat")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "dog "),
+            DiffSegment(type: .removed, element: "pig"),
+            DiffSegment(type: .inserted, element: "cat")
+        ])
+    }
+
+    private func diff(_ text: String, and otherText: String) -> [DiffSegment<String>] {
+        let stringTokenizer = WordStringTokenizer()
+        let sourceTokens = stringTokenizer.tokenize(text)
+        let destinationTokens = stringTokenizer.tokenize(otherText)
+        return destinationTokens.diffSegments(comparingWith: sourceTokens)
+    }
+}
+
+extension DiffSegment: Equatable where Element: Equatable {
+    public static func == (lhs: DiffSegment, rhs: DiffSegment) -> Bool {
+        (lhs.type, lhs.element) == (rhs.type, rhs.element)
+    }
+}


### PR DESCRIPTION
Small problem that I observed was that when word order changed a space would be inserted incorrectly.
This PR fixes that issue and adds few additional tests to ensure no bugs are introduced.

Before:
<img width="214" height="27" alt="Before" src="https://github.com/user-attachments/assets/3133ce0f-fbdc-4de3-81c0-0bbe2edb3453" />

After:
<img width="218" height="27" alt="After" src="https://github.com/user-attachments/assets/e84fab4d-35f4-4254-9f51-bf4f6fe7864c" />
