### PR TITLE
Diffs with punctation and whitespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .swiftpm
+.build/

--- a/Sources/TextDiffing/Internal/DiffSegment.swift
+++ b/Sources/TextDiffing/Internal/DiffSegment.swift
@@ -17,20 +17,55 @@ extension Array where Element == String {
         let source = other.refined(basedOn: destination)
 
         let diff = destination.difference(from: source)
-        var segments: [DiffSegment<Element>] = source.map { element in
-            return DiffSegment(type: .same, element: element)
-        }
-        var deletedOffsets: Set<Int> = []
+        var insertedByDestinationOffset: [Int: [Element]] = [:]
+        var removedBySourceOffset: [Int: [Element]] = [:]
+
         for change in diff {
             switch change {
             case let .insert(offset, element, _):
-                let deltaOffset = deletedOffsets.filter { $0 <= offset }.count
-                segments.insert(DiffSegment(type: .inserted, element: element), at: offset + deltaOffset)
+                insertedByDestinationOffset[offset, default: []].append(element)
             case let .remove(offset, element, _):
-                deletedOffsets.insert(offset)
-                segments[offset] = DiffSegment(type: .removed, element: element)
+                removedBySourceOffset[offset, default: []].append(element)
             }
         }
+
+        var sourceIndex = 0
+        var destinationIndex = 0
+        var segments: [DiffSegment<Element>] = []
+
+        while sourceIndex < source.count || destinationIndex < destination.count {
+            if let removed = removedBySourceOffset[sourceIndex], !removed.isEmpty {
+                for element in removed {
+                    segments.append(DiffSegment(type: .removed, element: element))
+                    sourceIndex += 1
+                }
+                continue
+            }
+
+            if let inserted = insertedByDestinationOffset[destinationIndex], !inserted.isEmpty {
+                for element in inserted {
+                    segments.append(DiffSegment(type: .inserted, element: element))
+                    destinationIndex += 1
+                }
+                continue
+            }
+
+            if sourceIndex < source.count, destinationIndex < destination.count {
+                segments.append(DiffSegment(type: .same, element: source[sourceIndex]))
+                sourceIndex += 1
+                destinationIndex += 1
+                continue
+            }
+
+            if sourceIndex < source.count {
+                segments.append(DiffSegment(type: .removed, element: source[sourceIndex]))
+                sourceIndex += 1
+            } else if destinationIndex < destination.count {
+                segments.append(DiffSegment(type: .inserted, element: destination[destinationIndex]))
+                destinationIndex += 1
+            }
+        }
+
         return segments.reduce(into: []) { result, segment in
             guard let lastSegment = result.last, segment.type == lastSegment.type else {
                 result.append(segment)

--- a/Sources/TextDiffing/Internal/DiffSegment.swift
+++ b/Sources/TextDiffing/Internal/DiffSegment.swift
@@ -13,8 +13,11 @@ struct DiffSegment<Element> {
 
 extension Array where Element == String {
     func diffSegments(comparingWith other: [Element]) -> [DiffSegment<Element>] {
-        let diff = difference(from: other)
-        var segments: [DiffSegment<Element>] = other.map { element in
+        let destination = refined(basedOn: other)
+        let source = other.refined(basedOn: destination)
+
+        let diff = destination.difference(from: source)
+        var segments: [DiffSegment<Element>] = source.map { element in
             return DiffSegment(type: .same, element: element)
         }
         var deletedOffsets: Set<Int> = []
@@ -38,5 +41,39 @@ extension Array where Element == String {
             result.removeLast()
             result.append(joinedDiffSegment)
         }
+    }
+
+    private func refined(basedOn referenceTokens: [String]) -> [String] {
+        let referenceSet = Set(referenceTokens)
+        return flatMap { token -> [String] in
+            if token.allSatisfy(\.isWhitespace) || referenceSet.contains(token) {
+                return [token]
+            }
+            return splitToken(token, using: referenceTokens) ?? [token]
+        }
+    }
+
+    private func splitToken(_ token: String, using referenceTokens: [String]) -> [String]? {
+        for startIdx in referenceTokens.indices {
+            let refToken = referenceTokens[startIdx]
+            guard !refToken.allSatisfy(\.isWhitespace),
+                  token.hasPrefix(refToken),
+                  token != refToken else { continue }
+
+            var accumulated = refToken
+            var parts = [refToken]
+            var j = startIdx + 1
+            while j < referenceTokens.count && accumulated.count < token.count {
+                let nextToken = referenceTokens[j]
+                j += 1
+                if nextToken.allSatisfy(\.isWhitespace) { continue }
+                accumulated += nextToken
+                parts.append(nextToken)
+            }
+            if accumulated == token {
+                return parts
+            }
+        }
+        return nil
     }
 }

--- a/Sources/TextDiffing/Internal/DiffSegment.swift
+++ b/Sources/TextDiffing/Internal/DiffSegment.swift
@@ -15,18 +15,9 @@ extension Array where Element == String {
     func diffSegments(comparingWith other: [Element]) -> [DiffSegment<Element>] {
         let destination = refined(basedOn: other)
         let source = other.refined(basedOn: destination)
-
-        let diff = destination.difference(from: source)
-        var insertedByDestinationOffset: [Int: [Element]] = [:]
-        var removedBySourceOffset: [Int: [Element]] = [:]
-        for change in diff {
-            switch change {
-            case let .insert(offset, element, _):
-                insertedByDestinationOffset[offset, default: []].append(element)
-            case let .remove(offset, element, _):
-                removedBySourceOffset[offset, default: []].append(element)
-            }
-        }
+        let (insertedByDestinationOffset, removedBySourceOffset) = changeMaps(
+            for: destination.difference(from: source)
+        )
 
         var sourceIndex = 0
         var destinationIndex = 0
@@ -73,6 +64,22 @@ extension Array where Element == String {
         }
 
         return segments
+    }
+
+    private func changeMaps(
+        for diff: CollectionDifference<Element>
+    ) -> ([Int: [Element]], [Int: [Element]]) {
+        var insertedByOffset: [Int: [Element]] = [:]
+        var removedByOffset: [Int: [Element]] = [:]
+        for change in diff {
+            switch change {
+            case let .insert(offset, element, _):
+                insertedByOffset[offset, default: []].append(element)
+            case let .remove(offset, element, _):
+                removedByOffset[offset, default: []].append(element)
+            }
+        }
+        return (insertedByOffset, removedByOffset)
     }
 
     private func refined(basedOn referenceTokens: [String]) -> [String] {

--- a/Sources/TextDiffing/Internal/DiffSegment.swift
+++ b/Sources/TextDiffing/Internal/DiffSegment.swift
@@ -19,7 +19,6 @@ extension Array where Element == String {
         let diff = destination.difference(from: source)
         var insertedByDestinationOffset: [Int: [Element]] = [:]
         var removedBySourceOffset: [Int: [Element]] = [:]
-
         for change in diff {
             switch change {
             case let .insert(offset, element, _):
@@ -32,11 +31,18 @@ extension Array where Element == String {
         var sourceIndex = 0
         var destinationIndex = 0
         var segments: [DiffSegment<Element>] = []
+        func appendSegment(_ type: DiffSegmentType, _ element: Element) {
+            guard let lastSegment = segments.last, lastSegment.type == type else {
+                segments.append(DiffSegment(type: type, element: element))
+                return
+            }
+            segments[segments.count - 1] = DiffSegment(type: type, element: lastSegment.element + element)
+        }
 
         while sourceIndex < source.count || destinationIndex < destination.count {
             if let removed = removedBySourceOffset[sourceIndex], !removed.isEmpty {
                 for element in removed {
-                    segments.append(DiffSegment(type: .removed, element: element))
+                    appendSegment(.removed, element)
                     sourceIndex += 1
                 }
                 continue
@@ -44,38 +50,29 @@ extension Array where Element == String {
 
             if let inserted = insertedByDestinationOffset[destinationIndex], !inserted.isEmpty {
                 for element in inserted {
-                    segments.append(DiffSegment(type: .inserted, element: element))
+                    appendSegment(.inserted, element)
                     destinationIndex += 1
                 }
                 continue
             }
 
             if sourceIndex < source.count, destinationIndex < destination.count {
-                segments.append(DiffSegment(type: .same, element: source[sourceIndex]))
+                appendSegment(.same, source[sourceIndex])
                 sourceIndex += 1
                 destinationIndex += 1
                 continue
             }
 
             if sourceIndex < source.count {
-                segments.append(DiffSegment(type: .removed, element: source[sourceIndex]))
+                appendSegment(.removed, source[sourceIndex])
                 sourceIndex += 1
             } else if destinationIndex < destination.count {
-                segments.append(DiffSegment(type: .inserted, element: destination[destinationIndex]))
+                appendSegment(.inserted, destination[destinationIndex])
                 destinationIndex += 1
             }
         }
 
-        return segments.reduce(into: []) { result, segment in
-            guard let lastSegment = result.last, segment.type == lastSegment.type else {
-                result.append(segment)
-                return
-            }
-            let joinedElement = lastSegment.element.appending(segment.element)
-            let joinedDiffSegment = DiffSegment(type: segment.type, element: joinedElement)
-            result.removeLast()
-            result.append(joinedDiffSegment)
-        }
+        return segments
     }
 
     private func refined(basedOn referenceTokens: [String]) -> [String] {

--- a/Sources/TextDiffing/Internal/WordStringTokenizer.swift
+++ b/Sources/TextDiffing/Internal/WordStringTokenizer.swift
@@ -14,7 +14,9 @@ struct WordStringTokenizer: StringTokenizer {
     }
 
     private func splitByCharacterCategory(_ token: String) -> [String] {
-        guard var previous = token.first else { return [] }
+        guard var previous = token.first else {
+            return []
+        }
         var result = [String(previous)]
         for char in token.dropFirst() {
             let sameCategory =

--- a/Sources/TextDiffing/Internal/WordStringTokenizer.swift
+++ b/Sources/TextDiffing/Internal/WordStringTokenizer.swift
@@ -14,37 +14,19 @@ struct WordStringTokenizer: StringTokenizer {
     }
 
     private func splitByCharacterCategory(_ token: String) -> [String] {
-        guard let firstChar = token.first else { return [] }
-        var result: [String] = []
-        var currentRun = String(firstChar)
-        var currentCategory = category(of: firstChar)
+        guard var previous = token.first else { return [] }
+        var result = [String(previous)]
         for char in token.dropFirst() {
-            let charCategory = category(of: char)
-            if charCategory != currentCategory {
-                result.append(currentRun)
-                currentRun = String(char)
-                currentCategory = charCategory
+            let sameCategory =
+                (char.isLetter || char.isNumber) == (previous.isLetter || previous.isNumber) &&
+                char.isWhitespace == previous.isWhitespace
+            if sameCategory {
+                result[result.count - 1].append(char)
             } else {
-                currentRun.append(char)
+                result.append(String(char))
             }
+            previous = char
         }
-        result.append(currentRun)
         return result
-    }
-
-    private enum CharacterCategory {
-        case word
-        case whitespace
-        case punctuation
-    }
-
-    private func category(of char: Character) -> CharacterCategory {
-        if char.isLetter || char.isNumber {
-            return .word
-        } else if char.isWhitespace {
-            return .whitespace
-        } else {
-            return .punctuation
-        }
     }
 }

--- a/Sources/TextDiffing/Internal/WordStringTokenizer.swift
+++ b/Sources/TextDiffing/Internal/WordStringTokenizer.swift
@@ -8,8 +8,43 @@ struct WordStringTokenizer: StringTokenizer {
         let range = NSRange(location: 0, length: text.utf16.count)
         tagger.enumerateTags(in: range, unit: .word, scheme: .tokenType) { _, tokenRange, _ in
             let word = (text as NSString).substring(with: tokenRange)
-            result.append(word)
+            result.append(contentsOf: splitByCharacterCategory(word))
         }
         return result
+    }
+
+    private func splitByCharacterCategory(_ token: String) -> [String] {
+        guard let firstChar = token.first else { return [] }
+        var result: [String] = []
+        var currentRun = String(firstChar)
+        var currentCategory = category(of: firstChar)
+        for char in token.dropFirst() {
+            let charCategory = category(of: char)
+            if charCategory != currentCategory {
+                result.append(currentRun)
+                currentRun = String(char)
+                currentCategory = charCategory
+            } else {
+                currentRun.append(char)
+            }
+        }
+        result.append(currentRun)
+        return result
+    }
+
+    private enum CharacterCategory {
+        case word
+        case whitespace
+        case punctuation
+    }
+
+    private func category(of char: Character) -> CharacterCategory {
+        if char.isLetter || char.isNumber {
+            return .word
+        } else if char.isWhitespace {
+            return .whitespace
+        } else {
+            return .punctuation
+        }
     }
 }

--- a/Tests/TextDiffingTests/TextDiffTests.swift
+++ b/Tests/TextDiffingTests/TextDiffTests.swift
@@ -204,6 +204,31 @@ import Foundation
         ])
     }
 
+    @Test func diffSegmentsWhenRemovingApostropheInContraction() async throws {
+        let diffSegments = diff("don't stop", and: "dont stop")
+        #expect(diffSegments == [
+            DiffSegment(type: .removed, element: "don't"),
+            DiffSegment(type: .inserted, element: "dont"),
+            DiffSegment(type: .same, element: " stop")
+        ])
+    }
+
+    @Test func diffSegmentsWhenReplacingHyphenWithSpace() async throws {
+        let diffSegments = diff("state-of-the-art", and: "state of the art")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "state"),
+            DiffSegment(type: .removed, element: "-"),
+            DiffSegment(type: .inserted, element: " "),
+            DiffSegment(type: .same, element: "of"),
+            DiffSegment(type: .removed, element: "-"),
+            DiffSegment(type: .inserted, element: " "),
+            DiffSegment(type: .same, element: "the"),
+            DiffSegment(type: .removed, element: "-"),
+            DiffSegment(type: .inserted, element: " "),
+            DiffSegment(type: .same, element: "art")
+        ])
+    }
+
     private func diff(_ text: String, and otherText: String) -> [DiffSegment<String>] {
         let stringTokenizer = WordStringTokenizer()
         let sourceTokens = stringTokenizer.tokenize(text)

--- a/Tests/TextDiffingTests/TextDiffTests.swift
+++ b/Tests/TextDiffingTests/TextDiffTests.swift
@@ -127,6 +127,42 @@ import Foundation
         ])
     }
 
+    @Test func diffSegmentsWhenRemovingSpaceBetweenWords() async throws {
+        let diffSegments = diff("Hello World", and: "HelloWorld")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "Hello"),
+            DiffSegment(type: .removed, element: " "),
+            DiffSegment(type: .same, element: "World")
+        ])
+    }
+
+    @Test func diffSegmentsWhenInsertingSpaceBetweenWords() async throws {
+        let diffSegments = diff("HelloWorld", and: "Hello World")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "Hello"),
+            DiffSegment(type: .inserted, element: " "),
+            DiffSegment(type: .same, element: "World")
+        ])
+    }
+
+    @Test func diffSegmentsWhenRemovingSpaceInFirstPairOfThreeWords() async throws {
+        let diffSegments = diff("one two three", and: "onetwo three")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "one"),
+            DiffSegment(type: .removed, element: " "),
+            DiffSegment(type: .same, element: "two three")
+        ])
+    }
+
+    @Test func diffSegmentsWhenRemovingSpaceInLastPairOfThreeWords() async throws {
+        let diffSegments = diff("one two three", and: "one twothree")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "one two"),
+            DiffSegment(type: .removed, element: " "),
+            DiffSegment(type: .same, element: "three")
+        ])
+    }
+
     @Test func diffSegmentsWhenChangingNumberAfterSymbol() async throws {
         let diffSegments = diff("price is $10", and: "price is $20")
         #expect(diffSegments == [

--- a/Tests/TextDiffingTests/TextDiffTests.swift
+++ b/Tests/TextDiffingTests/TextDiffTests.swift
@@ -172,6 +172,38 @@ import Foundation
         ])
     }
 
+    @Test func diffSegmentsWhenInsertingHashtagAndRemovingInternalSpace() async throws {
+        let diffSegments = diff("Fedora 44", and: "#Fedora44")
+        #expect(diffSegments == [
+            DiffSegment(type: .inserted, element: "#"),
+            DiffSegment(type: .same, element: "Fedora"),
+            DiffSegment(type: .removed, element: " "),
+            DiffSegment(type: .same, element: "44")
+        ])
+    }
+
+    @Test func diffSegmentsWhenInsertingMultipleHashtagsWithBoundaryRealignment() async throws {
+        let diffSegments = diff("macOS 26 Fedora 44", and: "#macOS 26 #Fedora44")
+        #expect(diffSegments == [
+            DiffSegment(type: .inserted, element: "#"),
+            DiffSegment(type: .same, element: "macOS 26 "),
+            DiffSegment(type: .inserted, element: "#"),
+            DiffSegment(type: .same, element: "Fedora"),
+            DiffSegment(type: .removed, element: " "),
+            DiffSegment(type: .same, element: "44")
+        ])
+    }
+
+    @Test func diffSegmentsWhenInsertingMultilineBreaks() async throws {
+        let diffSegments = diff("First. Second.", and: "First.\nSecond.")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "First."),
+            DiffSegment(type: .removed, element: " "),
+            DiffSegment(type: .inserted, element: "\n"),
+            DiffSegment(type: .same, element: "Second."),
+        ])
+    }
+
     private func diff(_ text: String, and otherText: String) -> [DiffSegment<String>] {
         let stringTokenizer = WordStringTokenizer()
         let sourceTokens = stringTokenizer.tokenize(text)

--- a/Tests/TextDiffingTests/TextDiffTests.swift
+++ b/Tests/TextDiffingTests/TextDiffTests.swift
@@ -5,9 +5,9 @@
 //  Created by Łukasz Rutkowski on 25/09/2025.
 //
 
+import Foundation
 import Testing
 @testable import TextDiffing
-import Foundation
 
 @Suite struct TextDiffTests {
 
@@ -200,7 +200,7 @@ import Foundation
             DiffSegment(type: .same, element: "First."),
             DiffSegment(type: .removed, element: " "),
             DiffSegment(type: .inserted, element: "\n"),
-            DiffSegment(type: .same, element: "Second."),
+            DiffSegment(type: .same, element: "Second.")
         ])
     }
 

--- a/Tests/TextDiffingTests/TextDiffTests.swift
+++ b/Tests/TextDiffingTests/TextDiffTests.swift
@@ -63,6 +63,79 @@ import Foundation
         ])
     }
 
+    @Test func diffSegmentsWhenDeletingSpace() async throws {
+        let diffSegments = diff(". onTapGesture", and: ".onTapGesture")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "."),
+            DiffSegment(type: .removed, element: " "),
+            DiffSegment(type: .same, element: "onTapGesture")
+        ])
+    }
+
+    @Test func diffSegmentsWhenInsertingSpace() async throws {
+        let diffSegments = diff(".onTapGesture", and: ". onTapGesture")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "."),
+            DiffSegment(type: .inserted, element: " "),
+            DiffSegment(type: .same, element: "onTapGesture")
+        ])
+    }
+
+    @Test func diffSegmentsWhenRemovingPeriodAtEndOfSentence() async throws {
+        let diffSegments = diff("Hello world.", and: "Hello world")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "Hello world"),
+            DiffSegment(type: .removed, element: ".")
+        ])
+    }
+
+    @Test func diffSegmentsWhenAppendingPunctuation() async throws {
+        let diffSegments = diff("Hello", and: "Hello!")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "Hello"),
+            DiffSegment(type: .inserted, element: "!")
+        ])
+    }
+
+    @Test func diffSegmentsWhenChangingWordNearParentheses() async throws {
+        let diffSegments = diff("func(a)", and: "func(b)")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "func("),
+            DiffSegment(type: .removed, element: "a"),
+            DiffSegment(type: .inserted, element: "b"),
+            DiffSegment(type: .same, element: ")")
+        ])
+    }
+
+    @Test func diffSegmentsWhenReplacingOperator() async throws {
+        let diffSegments = diff("a + b", and: "a - b")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "a "),
+            DiffSegment(type: .removed, element: "+"),
+            DiffSegment(type: .inserted, element: "-"),
+            DiffSegment(type: .same, element: " b")
+        ])
+    }
+
+    @Test func diffSegmentsWhenRemovingPunctuation() async throws {
+        let diffSegments = diff("Hello, world!", and: "Hello world")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "Hello"),
+            DiffSegment(type: .removed, element: ","),
+            DiffSegment(type: .same, element: " world"),
+            DiffSegment(type: .removed, element: "!")
+        ])
+    }
+
+    @Test func diffSegmentsWhenChangingNumberAfterSymbol() async throws {
+        let diffSegments = diff("price is $10", and: "price is $20")
+        #expect(diffSegments == [
+            DiffSegment(type: .same, element: "price is $"),
+            DiffSegment(type: .removed, element: "10"),
+            DiffSegment(type: .inserted, element: "20")
+        ])
+    }
+
     private func diff(_ text: String, and otherText: String) -> [DiffSegment<String>] {
         let stringTokenizer = WordStringTokenizer()
         let sourceTokens = stringTokenizer.tokenize(text)

--- a/Tests/TextDiffingTests/WordStringTokenizerTests.swift
+++ b/Tests/TextDiffingTests/WordStringTokenizerTests.swift
@@ -18,6 +18,20 @@ final class WordStringTokenizerTests {
     }
 
     @Test
+    func it_tokenizes_contractions() async throws {
+        let sut = WordStringTokenizer()
+        let result = sut.tokenize("don't stop")
+        #expect(result == ["do", "n", "'", "t", " ", "stop"])
+    }
+
+    @Test
+    func it_tokenizes_hyphenated_words() async throws {
+        let sut = WordStringTokenizer()
+        let result = sut.tokenize("state-of-the-art")
+        #expect(result == ["state", "-", "of", "-", "the", "-", "art"])
+    }
+
+    @Test
     func it_tokenizes_paragraph() async throws {
         let sut = WordStringTokenizer()
         // swiftlint:disable:next line_length


### PR DESCRIPTION
@simonbs 
This is a set of changes for various behaviors that I found to work unexpectedly while testing this package in my project for a few weeks.

8fb4dcc7787f2896ebfdcc9ad455439b9b9801df Introduces a change that splits what NSLinguisticTagger considers a word by punctuation/whitespace. I discovered that if someone removed whitespace between a punctuation and a word the diff would show 3 changes (removal of punctuation and word with insertion of their combination in between). After the change the diff shows a single removal of whitespace. 

1a3fa2d231f40ba078e3d3de329ab81726efc2e3 Is similar to previous commit but it improves the behavior to also works on changes that don't affect punctuation. This again results in a simple diff of removed/inserted whitespace instead of 3 separate changes.

8c2f0a424c97eae4fb841ffd6c15ed0a48d7ab23 Fixes a bug where an insertion of the same character in multiple places combined with removal could result in resulting diff showing insertion in completely wrong places.

All the situations I discovered are included in unit tests.
Disclaimer: Except for the tests AI was used to write the code, I did try to carefully review and manually correct all the changes.